### PR TITLE
Fix default import contract broken by modernizeLib PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eip",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eip",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "log4js": "^6.9.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eip",
   "description": "Enterprise Integration Patterns for javascript",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "dependencies": {
     "log4js": "^6.9.1"
   },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,12 @@
 import './register-routes';
-export { default as Route } from './route';
-export { default as Processor } from './processors/processor';
-export { default as Store } from './processors/aggregator/store';
-export { default as Timer } from './processors/aggregator/timer';
-export { default as PubSub } from './processors/throttler/pub-sub';
-export { default as Queue } from './processors/throttler/queue';
-export { default as AggregationStrategy } from './processors/aggregator/aggregation-strategy';
-export { init as initLogger, getLogger } from './logger';
+import Route from './route';
+import Processor from './processors/processor';
+import Store from './processors/aggregator/store';
+import Timer from './processors/aggregator/timer';
+import PubSub from './processors/throttler/pub-sub';
+import Queue from './processors/throttler/queue';
+import AggregationStrategy from './processors/aggregator/aggregation-strategy';
+import { init as initLogger, getLogger } from './logger';
+
+export { Route, Processor, Store, Timer, PubSub, Queue, AggregationStrategy, initLogger, getLogger };
+export default { Route, Processor, Store, Timer, PubSub, Queue, AggregationStrategy, initLogger, getLogger };


### PR DESCRIPTION
## Summary
- Clients using `import eip from 'eip'` were receiving `undefined` because the lib only had named exports and no default export
- Add a `default` export that exposes all named exports as a namespace object, restoring the broken contract
- Named exports are preserved, so existing `import { Route } from 'eip'` and `import * as eip from 'eip'` usage is unaffected
